### PR TITLE
Remove reference to polyfill.io

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -16,7 +16,7 @@
     <![endif]-->
 
     <!-- polyfill Intl for Safari mainly -->
-    <!-- <script src="https://cdn.polyfill.io/v2/polyfill.js?features=Intl"></script> -->
+    <!-- <script src="https://cdnjs.cloudflare.com/polyfill/v3/polyfill.min.js?features=Intl"></script> -->
 
     <style>
     :focus {


### PR DESCRIPTION
This replaces a references to `polyfill.io`, [which is now malware][0], with [Cloudflare's version][1].

I did not test this manually, but the code is already commented out, so this should have no impact.

[0]: https://www.theregister.com/2024/06/25/polyfillio_china_crisis/
[1]: https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet